### PR TITLE
Incorrect version of content-tutorial-platform-jar

### DIFF
--- a/actions/tutorial/tutorial.md
+++ b/actions/tutorial/tutorial.md
@@ -113,7 +113,7 @@ those need to go into the pom.xml file as module dependencies:
         <moduleDependency>
             <groupId>com.someco</groupId>
             <artifactId>content-tutorial-platform-jar</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0-SNAPSHOT</version>
             <type>amp</type>
         </moduleDependency>
         ...SNIP...


### PR DESCRIPTION
It should be 1.0-SNAPSHOT, not 1.0.0-SNAPSHOT