### PR TITLE
Incorrect artifactId used in actions-tutorial-integration-tests

### DIFF
--- a/actions/actions-tutorial/actions-tutorial-integration-tests/pom.xml
+++ b/actions/actions-tutorial/actions-tutorial-integration-tests/pom.xml
@@ -22,7 +22,7 @@
              that is generated for the AIO project -->
         <dependency>
             <groupId>com.someco</groupId>
-            <artifactId>actions-tutorial-platform-jar</artifactId>
+            <artifactId>actions-tutorial-platform</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
It should be "actions-tutorial-platform", not "actions-tutorial-platform-jar".

Otherwise `run.sh build_start` at actions-tutorial throws the following error:

```
[ERROR] Failed to execute goal on project actions-tutorial-integration-tests: 
Could not resolve dependencies for project 
com.someco:actions-tutorial-integration-tests:jar:1.0-SNAPSHOT: Failed to collect dependencies at 
com.someco:actions-tutorial-platform-jar:jar:1.0-SNAPSHOT: Failed to read artifact descriptor for 
com.someco:actions-tutorial-platform-jar:jar:1.0-SNAPSHOT: Could not transfer artifact 
com.someco:actions-tutorial-platform-jar:pom:1.0-SNAPSHOT from/to alfresco-private-repository
```